### PR TITLE
enble optional extra labels to the gauge

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ func (r *MyReconciler) SetStatusCondition(cr *v1.MyCR, cond metav1.Condition) bo
     updated := meta.FindStatusCondition(cr.Status.Conditions, cond.Type)
     if updated != nil {
         r.Recorder.RecordConditionFor(
-            kind, cr, updated.Type, string(updated.Status), updated.Reason, updated.LastTransitionTime,
+            kind, cr, updated.Type, 
+			string(updated.Status), updated.Reason, updated.LastTransitionTime.Time,
         )
     }
     return changed

--- a/pkg/crd-condition-metrics/metrics.go
+++ b/pkg/crd-condition-metrics/metrics.go
@@ -16,7 +16,7 @@ const (
 var (
 	indexLabels = []string{"controller", "kind", "name", "namespace"}
 	groupLabels = []string{"condition"}
-	extraLabels = []string{"status", "reason", "id"}
+	infoLabels = []string{"status", "reason", "id"}
 )
 
 type OperatorConditionsGauge struct {
@@ -32,7 +32,7 @@ type OperatorConditionsGauge struct {
 //	  OperatorConditionsGauge = NewOperatorConditionsGauge("my-operator")
 //	  controllermetrics.Registry.MustRegister(OperatorConditionsGauge)
 //	}
-func NewOperatorConditionsGauge(metricNamespace string) *OperatorConditionsGauge {
+func NewOperatorConditionsGauge(metricNamespace string, extraLabels...string) *OperatorConditionsGauge {
 	return &OperatorConditionsGauge{
 		metrics.NewGaugeVecSet(
 			metricNamespace,
@@ -41,7 +41,7 @@ func NewOperatorConditionsGauge(metricNamespace string) *OperatorConditionsGauge
 			operatorConditionMetricHelp,
 			indexLabels,
 			groupLabels,
-			extraLabels...,
+			append(infoLabels, extraLabels...)...,
 		),
 	}
 }
@@ -93,11 +93,13 @@ type ConditionMetricRecorder struct {
 func (r *ConditionMetricRecorder) RecordConditionFor(
 	kind string, object ObjectLike,
 	conditionType, conditionStatus, conditionReason string, lastTransitionTime time.Time,
+	extraLabelValues ...string,
 ) {
 	id := fmt.Sprintf("%s/%s", object.GetNamespace(), object.GetName())
 	indexValues := []string{r.Controller, kind, object.GetName(), object.GetNamespace()}
 	groupValues := []string{conditionType}
 	extraValues := []string{conditionStatus, conditionReason, id}
+	extraValues = append(extraValues, extraLabelValues...)
 
 	if lastTransitionTime.IsZero() {
 		lastTransitionTime = time.Now().UTC()

--- a/pkg/crd-condition-metrics/metrics.go
+++ b/pkg/crd-condition-metrics/metrics.go
@@ -16,7 +16,7 @@ const (
 var (
 	indexLabels = []string{"controller", "kind", "name", "namespace"}
 	groupLabels = []string{"condition"}
-	infoLabels = []string{"status", "reason", "id"}
+	infoLabels  = []string{"status", "reason", "id"}
 )
 
 type OperatorConditionsGauge struct {
@@ -32,7 +32,7 @@ type OperatorConditionsGauge struct {
 //	  OperatorConditionsGauge = NewOperatorConditionsGauge("my-operator")
 //	  controllermetrics.Registry.MustRegister(OperatorConditionsGauge)
 //	}
-func NewOperatorConditionsGauge(metricNamespace string, extraLabels...string) *OperatorConditionsGauge {
+func NewOperatorConditionsGauge(metricNamespace string, extraLabels ...string) *OperatorConditionsGauge {
 	return &OperatorConditionsGauge{
 		metrics.NewGaugeVecSet(
 			metricNamespace,

--- a/pkg/crd-condition-metrics/metrics_test.go
+++ b/pkg/crd-condition-metrics/metrics_test.go
@@ -18,7 +18,7 @@ func makeObj(name, namespace string) *FakeObject {
 	}
 }
 
-func TestConditionMetricRecorder_Record_Transition_And_SecondCondition(t *testing.T) {
+func TestConditionMetricRecorder_RecordConditionFor(t *testing.T) {
 	gauge := NewOperatorConditionsGauge("test_record_transition_and_second_condition")
 	reg := prometheus.NewRegistry()
 	_ = reg.Register(gauge)
@@ -50,6 +50,53 @@ func TestConditionMetricRecorder_Record_Transition_And_SecondCondition(t *testin
 # TYPE test_record_transition_and_second_condition_controller_condition gauge
 test_record_transition_and_second_condition_controller_condition{condition="Ready",controller="my-controller",id="prod/cr-1",kind="MyCRD",name="cr-1",namespace="prod",reason="Failed",status="False"} 1735689600
 test_record_transition_and_second_condition_controller_condition{condition="Synchronized",controller="my-controller",id="prod/cr-1",kind="MyCRD",name="cr-1",namespace="prod",reason="",status="True"} 1735689600
+`
+	require.NoError(t,
+		testutil.GatherAndCompare(
+			reg,
+			strings.NewReader(want),
+			"test_record_transition_and_second_condition_controller_condition",
+		),
+	)
+
+	removed := rec.RemoveConditionsFor(kind, obj)
+	assert.Equal(t, 2, removed)
+}
+
+func TestConditionMetricRecorder_RecordConditionFor_WithExtraLabels(t *testing.T) {
+	gauge := NewOperatorConditionsGauge(
+		"test_record_transition_and_second_condition", "zz_extra",
+	)
+	reg := prometheus.NewRegistry()
+	_ = reg.Register(gauge)
+
+	// Arrange
+	rec := &ConditionMetricRecorder{
+		Controller:              "my-controller",
+		OperatorConditionsGauge: gauge,
+	}
+	kind := "MyCRD"
+	name := "cr-1"
+	ns := "prod"
+	transitionTime := time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+	obj := makeObj(name, ns)
+
+	// Record Ready=True
+	rec.RecordConditionFor(kind, obj, "Ready", "True", "", transitionTime, "extra")
+
+	// Flip Ready -> False with reason
+	rec.RecordConditionFor(kind, obj, "Ready", "False", "Failed", transitionTime, "extra")
+
+	// Another condition Synchronized=True (independent group)
+	rec.RecordConditionFor(kind, obj, "Synchronized", "True", "", transitionTime, "extra")
+
+	// Expect: Ready False(reason)=1, Synchronized True=1
+	want := `
+# HELP test_record_transition_and_second_condition_controller_condition Condition status for a custom resource; one time series per (custom resource, condition type) combination.
+# TYPE test_record_transition_and_second_condition_controller_condition gauge
+test_record_transition_and_second_condition_controller_condition{condition="Ready",controller="my-controller",id="prod/cr-1",kind="MyCRD",name="cr-1",namespace="prod",reason="Failed",status="False",zz_extra="extra"} 1735689600
+test_record_transition_and_second_condition_controller_condition{condition="Synchronized",controller="my-controller",id="prod/cr-1",kind="MyCRD",name="cr-1",namespace="prod",reason="",status="True",zz_extra="extra"} 1735689600
 `
 	require.NoError(t,
 		testutil.GatherAndCompare(

--- a/pkg/crd-condition-metrics/metrics_test.go
+++ b/pkg/crd-condition-metrics/metrics_test.go
@@ -18,6 +18,10 @@ func makeObj(name, namespace string) *FakeObject {
 	}
 }
 
+const (
+	kind = "MyCRD"
+)
+
 func TestConditionMetricRecorder_RecordConditionFor(t *testing.T) {
 	gauge := NewOperatorConditionsGauge("test_record_transition_and_second_condition")
 	reg := prometheus.NewRegistry()
@@ -28,7 +32,6 @@ func TestConditionMetricRecorder_RecordConditionFor(t *testing.T) {
 		Controller:              "my-controller",
 		OperatorConditionsGauge: gauge,
 	}
-	kind := "MyCRD"
 	name := "cr-1"
 	ns := "prod"
 	transitionTime := time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC)
@@ -75,7 +78,6 @@ func TestConditionMetricRecorder_RecordConditionFor_WithExtraLabels(t *testing.T
 		Controller:              "my-controller",
 		OperatorConditionsGauge: gauge,
 	}
-	kind := "MyCRD"
 	name := "cr-1"
 	ns := "prod"
 	transitionTime := time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC)
@@ -119,7 +121,6 @@ func TestConditionMetricRecorder_RemoveConditionsFor(t *testing.T) {
 		Controller:              "my-controller",
 		OperatorConditionsGauge: gauge,
 	}
-	kind := "MyCRD"
 	name := "cr-2"
 	ns := "staging"
 	transitionTime := time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC)


### PR DESCRIPTION
To provide more flexibility, optional additional labels can be provided to the gauge.

Note that any amount of additional labels has no effect on the cardinality, since only one series is produced for each condition recorded for a CR.